### PR TITLE
Allow setting the read and write buffer size for interfacing with Cep…

### DIFF
--- a/README
+++ b/README
@@ -9,3 +9,4 @@ Current known issues :
   - in principle, paths can also be prepended with a similar string and a ':' to modify this default file by file. But this is currently broken (see next point for why)
   - paths that do not start with '/' get a slash appended in the server as they are considered relative.
 
+To get better (acceptable) read/write performance, set the parmeters GRIDFTP_CEPH_READ_SIZE and GRIDFTP_CEPH_WRITE_SIZE in the gridftp.conf file.

--- a/gridftp.conf
+++ b/gridftp.conf
@@ -1,0 +1,28 @@
+# globus-gridftp-server configuration file
+
+# this is a comment
+
+# option names beginning with '$' will be set as environment variables, e.g.
+# $GLOBUS_ERROR_VERBOSE 1
+# $GLOBUS_TCP_PORT_RANGE 50000,51000
+
+# port
+port 2811
+
+# 4194304
+# 8388608
+# 16777216
+# 33554432
+$GRIDFTP_CEPH_WRITE_SIZE 67108864
+
+$GRIDFTP_CEPH_READ_SIZE 67108864
+
+
+$GRIDFTP_CEPH_DEFAULTS diamond@rep-1
+daemon 1
+load_dsi_module ceph
+allowed_modules ceph
+log_single /var/log/gridftp.log
+log_transfer /var/log/globus-gridftp.log
+log_level ALL
+log_module stdio:buffer=0:interval=1


### PR DESCRIPTION
…h. Make some logging messages optional and remove some duplicated pathname information.

The plugin will now read the environment variables GRIDFTP_CEPH_READ_SIZE and GRIDFTP_CEPH_WRITE_SIZE. These allow the size of the buffers used in interfacing with Ceph (libradosstriper) to be increased from the defaul of 256MiB. Suggested valus for these
parameters is 64MiB. The gridftp.conf file contains these parameters set to 64MiB.
The symbol LOWLEVELTRACE is used in #ifdef statements in ceph_posix_{lseek, read, write} to reduce some of the logging noise.
The ceph_posix_stat64 no longer prints its function name and pathname as the latter is usually just a duplicate of the output from the preceding globus_l_gfs_ceph_stat invocation.
